### PR TITLE
Update build script from upstream.

### DIFF
--- a/tasks/build.sh
+++ b/tasks/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex -o pipefail
+set -e -o pipefail
 
 builder_path=${PWD}/builder-src
 stemcell_path=${PWD}/input-stemcell/*.tgz
@@ -39,9 +39,6 @@ cat > $CONFIG_PATH << EOF
   ]
 }
 EOF
-
-echo "Configuration:"
-cat $CONFIG_PATH
 
 extracted_stemcell_dir=${PWD}/extracted-stemcell
 mkdir -p ${extracted_stemcell_dir}


### PR DESCRIPTION
So that secrets aren't exposed in the build output. See https://github.com/cloudfoundry-incubator/aws-light-stemcell-builder/commit/2494cdeadac14c4ebcb779892839c1c51fd1ca27#diff-e45a9621c37b077f452167787160bf6b and https://github.com/cloudfoundry-incubator/aws-light-stemcell-builder/commit/a146df906f050b756083c7ddfdddcdfc1a27e618.