### PR TITLE
Encrypt s3

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -28,7 +28,7 @@ jobs:
       ami_access_key: {{publish_access_key}}
       ami_secret_key: {{publish_secret_key}}
       ami_bucket_name: {{publish_bucket}}
-      ami_server_side_encryption: "true"
+      ami_server_side_encryption: AES256
   - put: light-stemcell
     params:
       file: light-stemcell/light-bosh-stemcell-*.tgz
@@ -63,7 +63,7 @@ resources:
     branch: {{builder_config_git_branch}}
 
 - name: ubuntu-stemcell
-  type: bosh-io-stemcell-version-family
+  type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-ubuntu-trusty-go_agent
     force_regular: true
@@ -88,9 +88,3 @@ resource_types:
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
-
-- name: bosh-io-stemcell-version-family
-  type: docker-image
-  source:
-    repository: boshcpi/bosh-io-stemcell-resource
-    tag: PR-version-family

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -28,6 +28,7 @@ jobs:
       ami_access_key: {{publish_access_key}}
       ami_secret_key: {{publish_secret_key}}
       ami_bucket_name: {{publish_bucket}}
+      ami_server_side_encryption: "true"
   - put: light-stemcell
     params:
       file: light-stemcell/light-bosh-stemcell-*.tgz

--- a/tasks/build.sh
+++ b/tasks/build.sh
@@ -47,7 +47,7 @@ mkdir -p ${extracted_stemcell_dir}
 tar -C ${extracted_stemcell_dir} -xf ${stemcell_path}
 tar -xf ${extracted_stemcell_dir}/image
 
-original_stemcell_name="$(basename ${stemcell_path})"
+original_stemcell_name="$(basename $(cat ${PWD}/input-stemcell/url))"
 light_stemcell_name="light-${original_stemcell_name}"
 
 if [ "${ami_virtualization_type}" = "hvm" ]; then

--- a/tasks/build.sh
+++ b/tasks/build.sh
@@ -15,6 +15,7 @@ source ${builder_path}/ci/tasks/utils.sh
 : ${ami_access_key:?}
 : ${ami_secret_key:?}
 : ${ami_bucket_name:?}
+: ${ami_server_side_encryption:?}
 
 echo "Building light stemcell"
 
@@ -34,7 +35,8 @@ cat > $CONFIG_PATH << EOF
         "access_key":       "$ami_access_key",
         "secret_key":       "$ami_secret_key"
       },
-      "bucket_name":        "$ami_bucket_name"
+      "bucket_name":        "$ami_bucket_name",
+      "server_side_encryption": "$ami_server_side_encryption"
     }
   ]
 }


### PR DESCRIPTION
Depends on https://github.com/cloudfoundry-incubator/aws-light-stemcell-builder/pull/10; using our fork of the stemcell builder for now.

Note: for whatever reason, the name of the input stemcell changed, so to keep names consistent, I added the `original_stemcell_name="$(basename $(cat ${PWD}/input-stemcell/url))"` line. Better solutions welcome, but this does work.